### PR TITLE
feat: Add public nuspec (2.4.2)

### DIFF
--- a/choco/legal/LICENSE.txt
+++ b/choco/legal/LICENSE.txt
@@ -1,0 +1,23 @@
+From: https://github.com/qlik-oss/qlik-cli/blob/master/LICENSE
+
+The MIT License
+
+Copyright (c) 2020-present QlikTech International AB
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/choco/legal/VERIFICATION.txt
+++ b/choco/legal/VERIFICATION.txt
@@ -1,0 +1,13 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+1. Download the the qlik-Windows-x86_64.zip file from <https://github.com/qlik-oss/qlik-cli/releases/tag/v2.4.2>
+2. Unpack the archive
+3. Then use one of the following methods to obtain the checksum
+  - Use powershell function 'Get-Filehash qlik.exe'
+
+  checksum type: sha256
+  checksum: e6ee3d8fffce295e3e110639e22bba40707edf3e72fe89b3802c51bd484ef2d5
+
+File 'LICENSE.txt' is obtained from <https://github.com/qlik-oss/qlik-cli/blob/master/LICENSE>

--- a/choco/qlik-cli.nuspec
+++ b/choco/qlik-cli.nuspec
@@ -5,9 +5,9 @@
     <id>qlik-cli</id>
     <version>2.4.2</version>
     <projectUrl>https://github.com/qlik-oss/qlik-cli</projectUrl>
-    <packageSourceUrl>https://www.nuget.org/packages/qlik-cli</packageSourceUrl>
+    <packageSourceUrl>https://github.com/qlik-oss/qlik-cli/blob/master/choco</packageSourceUrl>
     <owners>QlikDevToolkit</owners>
-    <title>Qlik CLI</title>
+    <title>qlik CLI</title>
     <authors>Qliktech International AB</authors>
     <!-- Some of these will have to be added after the project is open-source -->
     <iconUrl>https://qlik-oss.github.io/qlik-cli.github.io/icons/qlik-cli.png</iconUrl>

--- a/choco/qlik-cli.nuspec
+++ b/choco/qlik-cli.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>qlik-cli</id>
+    <version>2.4.2</version>
+    <projectUrl>https://github.com/qlik-oss/qlik-cli</projectUrl>
+    <packageSourceUrl>https://www.nuget.org/packages/qlik-cli</packageSourceUrl>
+    <owners>QlikDevToolkit</owners>
+    <title>Qlik CLI</title>
+    <authors>Qliktech International AB</authors>
+    <!-- Some of these will have to be added after the project is open-source -->
+    <iconUrl>https://qlik-oss.github.io/qlik-cli.github.io/icons/qlik-cli.png</iconUrl>
+    <licenseUrl>https://github.com/qlik-oss/qlik-cli/blob/master/LICENSE</licenseUrl>
+    <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->
+    <docsUrl>https://qlik.dev/libraries-and-tools/qlik-cli</docsUrl>
+    <!--<mailingListUrl></mailingListUrl>-->
+    <bugTrackerUrl>https://github.com/qlik-oss/qlik-cli/issues</bugTrackerUrl>
+    <tags>qlik-cli</tags>
+    <summary>qlik is a tool for working with any of Qlik Sense SaaS</summary>
+    <description>qlik is a Command Line Interface for Qlik Sense SaaS.
+
+It gives you access to most public APIs which enables you to administrate your tenant and apps,
+develop and manage apps, migrate data and much more.</description>
+    <releaseNotes>
+## Release notes
+
+
+    </releaseNotes>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
+</package>


### PR DESCRIPTION
Adding the `.nuspec` with the other files that go into the to the `.nupkg` except for the executable itself which is found under [releases](https://github.com/qlik-oss/qlik-cli/releases) (in the `.zip`).