### PR TITLE
chore: Update nuspec and VERIFICATION.txt for v2.6.0

### DIFF
--- a/choco/legal/VERIFICATION.txt
+++ b/choco/legal/VERIFICATION.txt
@@ -2,12 +2,12 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-1. Download the the qlik-Windows-x86_64.zip file from <https://github.com/qlik-oss/qlik-cli/releases/tag/v2.5.1>
+1. Download the the qlik-Windows-x86_64.zip file from <https://github.com/qlik-oss/qlik-cli/releases/tag/v2.6.0>
 2. Unpack the archive
 3. Then use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash qlik.exe'
 
   checksum type: sha256
-  checksum: 44fb9d1b30bd391c3bb58f7d13630d39bd218204fade3c52607dab0a65e954de
+  checksum: 08fbe43bdc47f590788b3d3dee0d32dcb6387b06ff80d20457723e56b37f31b5
 
 File 'LICENSE.txt' is obtained from <https://github.com/qlik-oss/qlik-cli/blob/master/LICENSE>

--- a/choco/qlik-cli.nuspec
+++ b/choco/qlik-cli.nuspec
@@ -1,26 +1,57 @@
-<?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>qlik-cli</id>
-    <version>2.5.1</version>
+    <version>2.6.0</version>
+    <projectUrl>https://github.com/qlik-oss/qlik-cli</projectUrl>
+    <packageSourceUrl>https://github.com/qlik-oss/qlik-cli/blob/master/choco</packageSourceUrl>
+    <owners>QlikDevToolkit</owners>
     <title>qlik CLI</title>
     <authors>Qliktech International AB</authors>
-    <owners>QlikDevToolkit</owners>
-    <licenseUrl>https://github.com/qlik-oss/qlik-cli/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/qlik-oss/qlik-cli</projectUrl>
+    <!-- Some of these will have to be added after the project is open-source -->
     <iconUrl>https://qlik-oss.github.io/qlik-cli.github.io/icons/qlik-cli.png</iconUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/qlik-oss/qlik-cli/blob/master/LICENSE</licenseUrl>
+    <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->
+    <docsUrl>https://qlik.dev/libraries-and-tools/qlik-cli</docsUrl>
+    <!--<mailingListUrl></mailingListUrl>-->
+    <bugTrackerUrl>https://github.com/qlik-oss/qlik-cli/issues</bugTrackerUrl>
+    <tags>qlik-cli</tags>
+    <summary>qlik is a tool for working with any of Qlik Sense SaaS</summary>
     <description>qlik is a Command Line Interface for Qlik Sense SaaS.
 
 It gives you access to most public APIs which enables you to administrate your tenant and apps,
 develop and manage apps, migrate data and much more.</description>
-    <summary>qlik is a tool for working with any of Qlik Sense SaaS</summary>
-    <releaseNotes>## Release notes
+    <releaseNotes>
+## Release notes
 
-- Fix: YAML-spec support</releaseNotes>
-    <tags>qlik-cli</tags>
-    <packageSourceUrl>https://github.com/qlik-oss/qlik-cli/blob/master/choco</packageSourceUrl>
-    <docsUrl>https://qlik.dev/libraries-and-tools/qlik-cli</docsUrl>
-    <bugTrackerUrl>https://github.com/qlik-oss/qlik-cli/issues</bugTrackerUrl>
+- New: Added `qlik edit` command - you can now easily update resources without worrying about 
+the complicated JSON Patch calculations, based on the `EDITOR` environment variable, the edit 
+command will start automatically your preferred editor and once you changes are saved, will 
+do all the PUT/PATCH work for you.
+    *If you want to see communication details for your edit call you can use the `--verbose` 
+    flag. This will display all HTTP operations that are performed including payloads for requests.*
+    example:
+    ```bash
+    qlik webhook edit &lt;webhookId&gt;
+    # this command will launch your preferred editor containing the resource in json format
+    # changing for example the description parameter and save will be the equivalent of doing 
+    # a patch with payload:
+    # [
+    #   {
+    #       "op": "replace",
+    #       "path": "/description",
+    #       "value": "my new description"
+    #   }
+    # ]
+    ```
+- New: Added `qlik spec get` provides more detailed information about added external specs, most notably the path to the added specification.
+- New: The auto-generated usage documentation now get automatically published to https://qlik.dev/libraries-and-tools/qlik-cli upon new releases.
+- Fix: Improved robustness in handling of array subtypes - missing types will now return errors. Any included schema is thus required to have proper types defined. Previously, we defaulted to string if the type was missing.
+    </releaseNotes>
   </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
 </package>


### PR DESCRIPTION
This is normally done automatically.

This updates the `qlik-cli.nuspec` to that of the latest release (v2.6.0) and updates the verification instructions accordingly.